### PR TITLE
修复存档界面的徽章单位显示问题

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -2271,11 +2271,12 @@ void BufferSaveMenuText(u8 textId, u8 *dest, u8 color)
                 if (FlagGet(curFlag))
                     flagCount++;
             }
-            *string = flagCount + CHAR_0;
-                    string++;
             //修改，增加徽章单位显示
-            StringAppend(string, COMPOUND_STRING("个"));
+            //*string = flagCount + CHAR_0;
             //*string++ = EOS; //修正错误
+            //*endOfString = EOS;
+            ConvertIntToDecimalStringN(string, flagCount, STR_CONV_MODE_LEADING_ZEROS, 1);
+            StringAppend(string, COMPOUND_STRING("个"));
             *endOfString = EOS;
             break;
     }


### PR DESCRIPTION
上次统一修改StringAppend函数后，出现了存档界面徽章单位显示乱码的问题，目前已经修复……
<img width="240" height="160" alt="fix_save_menu" src="https://github.com/user-attachments/assets/68fc66c4-538d-4624-8748-9811de0a3f19" />
